### PR TITLE
Fix YAML syntax error in incident responder template

### DIFF
--- a/examples/security_agents/incident-responder.yaml
+++ b/examples/security_agents/incident-responder.yaml
@@ -61,7 +61,7 @@ tasks:
       properties:
         incident_id:
           type: string
-          description: Unique incident identifier (format: INC-YYYY-NNNN)
+          description: "Unique incident identifier (format: INC-YYYY-NNNN)"
         response_plan:
           type: array
           items:


### PR DESCRIPTION
- Quote description containing colon to prevent YAML parsing error
- Changed description: Unique incident identifier (format: INC-YYYY-NNNN)
- To: description: "Unique incident identifier (format: INC-YYYY-NNNN)"
- Fixes 'mapping values are not allowed here' error at line 64

This resolves the YAML parsing error that prevented users from generating the incident responder agent.